### PR TITLE
refactor(scheduling): deliver cron and heartbeat runs via internal signal workers

### DIFF
--- a/doc/internals/cron-permission-refresh.md
+++ b/doc/internals/cron-permission-refresh.md
@@ -1,0 +1,20 @@
+# Cron Permission Refresh
+
+## Summary
+
+Cron agents rebuild their workspace permissions before each message so they run in the task files directory. Previously this reset dropped runtime-granted permissions (for example `@network`) because the rebuild started only from default permissions.
+
+The fix keeps cron workspace enforcement while carrying forward already granted runtime permissions.
+
+## Flow
+
+```mermaid
+graph TD
+  A[Current session permissions] --> B[permissionBuildCronSession]
+  D[Default permissions] --> B
+  E[Cron filesPath] --> B
+  B --> C[Rebuilt cron permissions]
+  C --> F[workingDir forced to cron filesPath]
+  C --> G[network/events preserved when already granted]
+  C --> H[read/write directories unioned with current grants]
+```

--- a/doc/internals/scheduler-signal-workers.md
+++ b/doc/internals/scheduler-signal-workers.md
@@ -1,0 +1,21 @@
+# Scheduler Signal Workers
+
+## Summary
+
+Cron and heartbeat schedulers now deliver work to worker agents as internal signal events instead of posting direct message items.
+
+- Cron tasks emit `internal.cron.task` to the `system:cron` worker.
+- Heartbeat batches emit `internal.heartbeat.tick` to the `system:heartbeat` worker.
+- Agent signal handling accepts these internal scheduler patterns without requiring persisted user subscriptions.
+
+## Flow
+
+```mermaid
+graph LR
+  CronScheduler -->|gates + prompt| CronSignal[internal.cron.task]
+  CronSignal --> CronWorker[system:cron]
+  HeartbeatScheduler -->|gates + prompt| HeartbeatSignal[internal.heartbeat.tick]
+  HeartbeatSignal --> HeartbeatWorker[system:heartbeat]
+  CronWorker --> AgentLoop[agent inference loop]
+  HeartbeatWorker --> AgentLoop
+```

--- a/packages/daycare/sources/engine/agents/system/_systemAgents.ts
+++ b/packages/daycare/sources/engine/agents/system/_systemAgents.ts
@@ -11,6 +11,11 @@ export const SYSTEM_AGENTS: readonly SystemAgentDefinition[] = [
     replaceSystemPrompt: false
   },
   {
+    tag: "cron",
+    promptFile: "CRON.md",
+    replaceSystemPrompt: false
+  },
+  {
     tag: "architect",
     promptFile: "ARCHITECT.md",
     replaceSystemPrompt: true

--- a/packages/daycare/sources/engine/agents/system/systemAgentPromptResolve.spec.ts
+++ b/packages/daycare/sources/engine/agents/system/systemAgentPromptResolve.spec.ts
@@ -10,6 +10,14 @@ describe("systemAgentPromptResolve", () => {
     expect(heartbeat?.replaceSystemPrompt).toBe(false);
   });
 
+
+  it("resolves cron prompt without replacing base system prompt", async () => {
+    const cron = await systemAgentPromptResolve("cron");
+    expect(cron?.tag).toBe("cron");
+    expect(cron?.systemPrompt.length).toBeGreaterThan(0);
+    expect(cron?.replaceSystemPrompt).toBe(false);
+  });
+
   it("resolves architect prompt with full prompt replacement enabled", async () => {
     const architect = await systemAgentPromptResolve("architect");
     expect(architect?.tag).toBe("architect");

--- a/packages/daycare/sources/engine/permissions/permissionBuildCronSession.spec.ts
+++ b/packages/daycare/sources/engine/permissions/permissionBuildCronSession.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionPermissions } from "@/types";
+
+import { permissionBuildCronSession } from "./permissionBuildCronSession.js";
+
+describe("permissionBuildCronSession", () => {
+  it("keeps runtime grants while enforcing cron workspace", () => {
+    const defaults: SessionPermissions = {
+      workingDir: "/workspace/daycare",
+      writeDirs: ["/workspace/daycare"],
+      readDirs: ["/workspace/daycare"],
+      network: false,
+      events: false
+    };
+    const current: SessionPermissions = {
+      workingDir: "/tmp/old-cron",
+      writeDirs: ["/tmp/old-cron", "/tmp/granted-write"],
+      readDirs: ["/tmp/old-cron", "/tmp/granted-read"],
+      network: true,
+      events: true
+    };
+
+    const result = permissionBuildCronSession(current, defaults, "/tmp/new-cron");
+
+    expect(result.workingDir).toBe("/tmp/new-cron");
+    expect(result.network).toBe(true);
+    expect(result.events).toBe(true);
+    expect(result.writeDirs).toEqual(
+      expect.arrayContaining(["/workspace/daycare", "/tmp/old-cron", "/tmp/granted-write"])
+    );
+    expect(result.readDirs).toEqual(
+      expect.arrayContaining(["/workspace/daycare", "/tmp/old-cron", "/tmp/granted-read"])
+    );
+  });
+});

--- a/packages/daycare/sources/engine/permissions/permissionBuildCronSession.ts
+++ b/packages/daycare/sources/engine/permissions/permissionBuildCronSession.ts
@@ -1,0 +1,25 @@
+import type { SessionPermissions } from "@/types";
+
+import { permissionBuildCron } from "./permissionBuildCron.js";
+
+/**
+ * Builds cron base permissions and carries forward runtime-granted permissions.
+ * Expects: filesPath is the cron workspace path; current permissions are normalized.
+ */
+export function permissionBuildCronSession(
+  currentPermissions: SessionPermissions,
+  defaultPermissions: SessionPermissions,
+  filesPath: string
+): SessionPermissions {
+  const cronPermissions = permissionBuildCron(defaultPermissions, filesPath);
+  const writeDirs = new Set([...cronPermissions.writeDirs, ...currentPermissions.writeDirs]);
+  const readDirs = new Set([...cronPermissions.readDirs, ...currentPermissions.readDirs]);
+
+  return {
+    ...cronPermissions,
+    writeDirs: Array.from(writeDirs.values()),
+    readDirs: Array.from(readDirs.values()),
+    network: cronPermissions.network || currentPermissions.network,
+    events: cronPermissions.events || currentPermissions.events
+  };
+}

--- a/packages/daycare/sources/prompts/ACTORS.md
+++ b/packages/daycare/sources/prompts/ACTORS.md
@@ -1,25 +1,33 @@
 # ACTORS.md
 
-Known agents, their roles, and signal subscriptions. Update this as agents are created or signal wiring changes.
+Known agents, their roles, and signal subscriptions.
 
 ## Agents
 
 | Name | Kind | Role |
 |------|------|------|
-| | | |
+| heartbeat worker (`system:heartbeat`) | system | Processes scheduled heartbeat signal events and executes heartbeat prompts. |
+| cron worker (`system:cron`) | system | Processes scheduled cron signal events and executes cron prompts. |
+| user sessions | user | Foreground user interaction, tool execution, and permission orchestration. |
+| background sessions | cron/subagent/permanent | Autonomous task execution and orchestration flows. |
 
 ## Signal Subscriptions
 
 | Agent | Pattern | Silent | Purpose |
 |-------|---------|--------|---------|
-| | | | |
+| `system:heartbeat` | `internal.heartbeat.tick` | false | Receives scheduler heartbeat batches as direct signal events. |
+| `system:cron` | `internal.cron.task` | false | Receives scheduler cron executions as direct signal events. |
 
 ## Wiring Diagram
 
 ```mermaid
 graph LR
+  HeartbeatScheduler -->|internal.heartbeat.tick| HeartbeatWorker[system:heartbeat]
+  CronScheduler -->|internal.cron.task| CronWorker[system:cron]
+  HeartbeatWorker -->|tool execution + responses| Runtime[Engine Runtime]
+  CronWorker -->|tool execution + responses| Runtime
 ```
 
 ## Notes
 
--
+- Scheduler-originated internal signals are delivered directly and do not require persisted user subscriptions.

--- a/packages/daycare/sources/prompts/CRON.md
+++ b/packages/daycare/sources/prompts/CRON.md
@@ -1,0 +1,8 @@
+# CRON WORKER
+
+You are the Daycare cron worker.
+
+- Treat incoming signal events as scheduler-triggered cron tasks.
+- Parse the signal payload and execute the task prompt carefully.
+- Respect granted permissions and avoid requesting unnecessary escalation.
+- When reporting results, keep output concise and actionable.


### PR DESCRIPTION
### Motivation

- Scheduler-driven work (cron/heartbeat) should be delivered to dedicated worker agents and not be mixed into the generic agent message path so agents remain scheduler-agnostic. 
- Delivering scheduler work as internal signals keeps gate/prep logic and workspace enforcement inside the scheduler while allowing the worker to run the prepared prompt with the correct permissions. 
- Internal scheduler signals should be accepted even when no user subscription exists so scheduled work can be reliably delivered to system workers.

### Description

- Cron runs are dispatched as a `signal` with `type`/`subscriptionPattern` `internal.cron.task` (payload contains prompt, task meta, paths, and message context) and delivered to a `system:cron` worker; the scheduler refreshes the worker's permissions before posting. (`packages/daycare/sources/engine/cron/crons.ts`).
- Heartbeat batches are dispatched as a `signal` with `type`/`subscriptionPattern` `internal.heartbeat.tick` (payload contains the batch prompt and task summaries) and delivered to the `system:heartbeat` worker, with permissions refreshed before dispatch. (`packages/daycare/sources/engine/heartbeat/heartbeats.ts`).
- Agent signal handling now treats `internal.*` patterns as internal scheduler signals that may be delivered without a persisted subscription, and preserves appropriate `silent` semantics for non-internal signals. (`packages/daycare/sources/engine/agents/agent.ts`).
- Removed cron-specific permission rebuilding from the generic agent `handleMessage` flow to keep agents decoupled from scheduler concerns (scheduler now refreshes worker permissions before dispatch). (`packages/daycare/sources/engine/agents/agent.ts`).
- Added a built-in `system:cron` worker prompt and registered the `cron` system agent. (`packages/daycare/sources/engine/agents/system/_systemAgents.ts`, `packages/daycare/sources/prompts/CRON.md`).
- Updated actor topology docs and added an architecture note describing scheduler → internal-signal → worker flow with mermaid diagrams. (`packages/daycare/sources/prompts/ACTORS.md`, `doc/internals/scheduler-signal-workers.md`).

### Testing

- Type-check: ran `tsc` for the package with engine checks skipped; `yarn --ignore-engines --cwd packages/daycare typecheck` succeeded. 
- Unit/test runs: ran `vitest` for key specs including `agent.spec.ts` and `systemAgentPromptResolve.spec.ts`, and they passed (tests exercised new internal-signal delivery flow and system agent prompt resolution). 
- Notes: the repository requires Node >=22; in this environment `yarn --cwd packages/daycare typecheck` fails against the engine constraint, so checks/tests were executed with `--ignore-engines` where necessary and those runs succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd3c8762c8322bb242dda6d6281eb)