### PR TITLE
feat(telegram): add support for group and supergroup chats

### DIFF
--- a/packages/daycare/sources/plugins/telegram/connector.ts
+++ b/packages/daycare/sources/plugins/telegram/connector.ts
@@ -121,8 +121,9 @@ export class TelegramConnector implements Connector {
     };
 
     this.bot.on("message", async (message) => {
-      if (message.chat?.type !== "private") {
-        logger.debug(`skip: Skipping non-private chat type=${message.chat?.type} chatId=${message.chat?.id}`);
+      const chatType = message.chat?.type;
+      if (chatType !== "private" && chatType !== "group" && chatType !== "supergroup") {
+        logger.debug(`skip: Skipping unsupported chat type=${chatType} chatId=${message.chat?.id}`);
         return;
       }
       const senderId = message.from?.id ?? message.chat?.id;


### PR DESCRIPTION
Previously the Telegram connector only handled private chats. This change allows the bot to respond in group and supergroup chats when the chat ID is in the allowedUids list.