### PR TITLE
Improve user-facing context reset messages

### DIFF
--- a/packages/daycare/sources/engine/agents/ops/messageContextReset.spec.ts
+++ b/packages/daycare/sources/engine/agents/ops/messageContextReset.spec.ts
@@ -4,26 +4,36 @@ import { messageContextReset } from "./messageContextReset.js";
 describe("messageContextReset", () => {
   it("returns compaction message", () => {
     const result = messageContextReset({ kind: "compaction" });
-    expect(result).toBe("⏳ Compacting session context. I'll continue shortly.");
+    expect(result).toBe("⏳ Tidying up our conversation — back in a moment!");
   });
 
   it("returns manual reset message", () => {
     const result = messageContextReset({ kind: "manual" });
-    expect(result).toBe("🔄 Session reset.");
+    expect(result).toBe("🔄 Fresh start! How can I help?");
   });
 
   it("returns overflow message without tokens", () => {
     const result = messageContextReset({ kind: "overflow" });
-    expect(result).toBe("⚠️ Session reset — context overflow. Please resend your last message.");
+    expect(result).toBe("⚠️ Our conversation got too long, so I had to start fresh. Could you repeat your last message?");
   });
 
-  it("returns overflow message with token count", () => {
+  it("returns overflow message with high token count", () => {
     const result = messageContextReset({ kind: "overflow", estimatedTokens: 153_200 });
-    expect(result).toBe("⚠️ Session reset — context overflow (~153k tokens). Please resend your last message.");
+    expect(result).toBe("⚠️ Our conversation got really long, so I had to start fresh. Could you repeat your last message?");
   });
 
-  it("omits token count when zero", () => {
+  it("returns overflow message with medium token count", () => {
+    const result = messageContextReset({ kind: "overflow", estimatedTokens: 100_000 });
+    expect(result).toBe("⚠️ Our conversation got quite long, so I had to start fresh. Could you repeat your last message?");
+  });
+
+  it("returns overflow message with lower token count", () => {
+    const result = messageContextReset({ kind: "overflow", estimatedTokens: 50_000 });
+    expect(result).toBe("⚠️ Our conversation got a bit too long, so I had to start fresh. Could you repeat your last message?");
+  });
+
+  it("returns overflow message with zero tokens", () => {
     const result = messageContextReset({ kind: "overflow", estimatedTokens: 0 });
-    expect(result).toBe("⚠️ Session reset — context overflow. Please resend your last message.");
+    expect(result).toBe("⚠️ Our conversation got too long, so I had to start fresh. Could you repeat your last message?");
   });
 });

--- a/packages/daycare/sources/engine/agents/ops/messageContextReset.ts
+++ b/packages/daycare/sources/engine/agents/ops/messageContextReset.ts
@@ -17,15 +17,28 @@ export type MessageContextResetOptions = {
 export function messageContextReset(options: MessageContextResetOptions): string {
   switch (options.kind) {
     case "compaction":
-      return "⏳ Compacting session context. I'll continue shortly.";
+      return "⏳ Tidying up our conversation — back in a moment!";
     case "manual":
-      return "🔄 Session reset.";
+      return "🔄 Fresh start! How can I help?";
     case "overflow": {
-      const tokens = options.estimatedTokens ?? 0;
-      const tokensPart = tokens > 0
-        ? ` (~${Math.round(tokens / 1000)}k tokens)`
-        : "";
-      return `⚠️ Session reset — context overflow${tokensPart}. Please resend your last message.`;
+      const lengthHint = describeConversationLength(options.estimatedTokens ?? 0);
+      return `⚠️ Our conversation got ${lengthHint}, so I had to start fresh. Could you repeat your last message?`;
     }
   }
+}
+
+/**
+ * Returns a human-friendly description of conversation length based on token count.
+ */
+function describeConversationLength(tokens: number): string {
+  if (tokens >= 150_000) {
+    return "really long";
+  }
+  if (tokens >= 100_000) {
+    return "quite long";
+  }
+  if (tokens >= 50_000) {
+    return "a bit too long";
+  }
+  return "too long";
 }


### PR DESCRIPTION
## Summary
Improves the user-facing messages shown when context resets happen.

## Changes

### Before
- **Overflow**: `⚠️ Session reset — context overflow (~153k tokens). Please resend your last message.`
- **Compaction**: `⏳ Compacting session context. I'll continue shortly.`
- **Manual**: `🔄 Session reset.`

### After  
- **Overflow**: `⚠️ Our conversation got really long, so I had to start fresh. Could you repeat your last message?`
- **Compaction**: `⏳ Tidying up our conversation — back in a moment!`
- **Manual**: `🔄 Fresh start! How can I help?`

## Design Decisions

1. **No raw token counts** - Users don't know what "153k tokens" means. Instead, we describe length naturally:
   - `>= 150k tokens` → "really long"
   - `>= 100k tokens` → "quite long"  
   - `>= 50k tokens` → "a bit too long"
   - `< 50k tokens` → "too long"

2. **Warmer tone** - Changed technical language like "context overflow" to friendly phrases like "our conversation got too long"

3. **Clear action** - Changed "Please resend your last message" to "Could you repeat your last message?" (more conversational)

## Testing
- Updated test cases to match new messages
- Added additional test cases for different token thresholds
